### PR TITLE
chore: for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,58 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main  
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Site
+        run: pnpm run build
+
+      - name: Add CNAME file
+        run: echo "coco.rs" > docs/CNAME
+
+      - name: Upload Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment of the project to GitHub Pages. The key changes include setting up the workflow to trigger on pushes to the `main` branch and manually via `workflow_dispatch`, configuring the environment, and defining the steps for building and deploying the site.

Deployment automation:

* Added a new workflow configuration file `.github/workflows/deploy.yml` to automate deployment to GitHub Pages.
* Configured the workflow to trigger on pushes to the `main` branch and via manual dispatch.
* Set up the environment with `pnpm` and `Node.js`, including caching for dependencies.
* Defined steps to install dependencies, build the site, and deploy to GitHub Pages.