### PR TITLE
chore: for deploy with pnp

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Build Site
         run: pnpm run build


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/deploy.yml` file. The change modifies the dependency installation command to no longer use the `--frozen-lockfile` option. 

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L44-R44): Changed the dependency installation command from `pnpm install --frozen-lockfile` to `pnpm install`.