### PR TITLE
chore: update version by url

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -53,6 +53,20 @@ jobs:
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
+
+      - name: Update data.json with latest version
+        run: |
+          set -euo pipefail
+
+          VERSION_INFO=$(curl -s --fail --max-time 10 https://release.infinilabs.com/.latest)
+          APP_VERSION=$(echo "$VERSION_INFO" | jq -r '.["coco-app"]')
+          SERVER_VERSION=$(echo "$VERSION_INFO" | jq -r '.["coco-server"]')
+          if ! [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$ ]] || ! [[ "$SERVER_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$ ]]; then
+            echo "Error: Invalid version format." >&2  # 输出到 stderr
+            exit 1
+          fi
+          jq --arg app "$APP_VERSION" --arg server "$SERVER_VERSION" '.app = $app | .server = $server' public/data.json > temp.json && mv temp.json public/data.json
+          
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -62,7 +62,7 @@ jobs:
           APP_VERSION=$(echo "$VERSION_INFO" | jq -r '.["coco-app"]')
           SERVER_VERSION=$(echo "$VERSION_INFO" | jq -r '.["coco-server"]')
           if ! [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$ ]] || ! [[ "$SERVER_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+$ ]]; then
-            echo "Error: Invalid version format." >&2  # 输出到 stderr
+            echo "Error: Invalid version format." >&2
             exit 1
           fi
           jq --arg app "$APP_VERSION" --arg server "$SERVER_VERSION" '.app = $app | .server = $server' public/data.json > temp.json && mv temp.json public/data.json


### PR DESCRIPTION
This pull request includes an update to the deployment workflow for the site. The most important change involves adding a new step to update the `data.json` file with the latest version information from the Infinilabs release server.

Deployment workflow update:

* [`.github/workflows/deploy-site.yml`](diffhunk://#diff-0b263af13139bf9e35cf8d76ee84f4a007e7dc1d35f1f45c282eeec1449e6ce1R56-R69): Added a new step to fetch the latest version information for `coco-app` and `coco-server` from the Infinilabs release server and update `public/data.json` accordingly. This step includes validation of the version format and ensures the data is correctly written to the JSON file.