### PR TITLE
chore: add log version for publish docs

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -67,7 +67,10 @@ jobs:
             echo "Error: Invalid version format." >&2
             exit 1
           fi
+          echo "Publish app version: $APP_VERSION, server version: $SERVER_VERSION"
+          # Update the JSON file with the new version
           jq --arg app "$APP_VERSION" --arg server "$SERVER_VERSION" '.app = $app | .server = $server' public/data.json > temp.json && mv temp.json public/data.json
+          cat public/data.json
           
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
This pull request updates the deployment workflow to improve logging and ensure the version information is correctly updated in the JSON file.

### Deployment workflow updates:
* [`.github/workflows/deploy-site.yml`](diffhunk://#diff-0b263af13139bf9e35cf8d76ee84f4a007e7dc1d35f1f45c282eeec1449e6ce1R70-R73): Added a log statement to display the app and server versions being published. Updated the workflow to print the contents of `public/data.json` after modifying it with the new version information.