### PR TITLE
chore: change ci with NODE_ENV

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -33,28 +33,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Detect package manager
-        id: detect-package-manager
-        run: |
-          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
-            echo "manager=yarn" >> $GITHUB_OUTPUT
-            echo "command=install" >> $GITHUB_OUTPUT
-            echo "runner=yarn" >> $GITHUB_OUTPUT
-            exit 0
-          elif [ -f "${{ github.workspace }}/package.json" ]; then
-            echo "manager=npm" >> $GITHUB_OUTPUT
-            echo "command=ci" >> $GITHUB_OUTPUT
-            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
-            exit 0
-          else
-            echo "Unable to determine package manager"
-            exit 1
-          fi
+        
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: ${{ steps.detect-package-manager.outputs.manager }}
+          cache: 'pnpm'
 
       - name: Update data.json with latest version
         run: |
@@ -80,6 +68,7 @@ jobs:
           #
           # You may remove this line if you want to manage the configuration yourself.
           static_site_generator: next
+
       - name: Restore cache
         uses: actions/cache@v4
         with:
@@ -89,19 +78,26 @@ jobs:
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}
+
       - name: Install dependencies
-        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+        run: pnpm install --registry=https://registry.npmjs.org --quiet
+
       - name: Build with Web
-        run: ${{ steps.detect-package-manager.outputs.runner }} next build
+        env:
+          NODE_ENV: production
+        run: pnpm build
+
       - name: Add CNAME file
-        run: echo "coco.rs" > ./out/CNAME
+        run: echo "coco.rs" > ./docs/CNAME
+
       - name: Disable Jekyll
-        run: touch out/.nojekyll
+        run: touch docs/.nojekyll
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./out
+          path: ./docs
 
   # Deployment job
   deploy:

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,14 +7,14 @@ const nextConfig: NextConfig = {
   images: {
     dangerouslyAllowSVG: true,
     contentDispositionType: "attachment",
-contentSecurityPolicy: `
-  default-src 'self';
-  script-src 'self' https://coco.infini.cloud;
-  style-src 'self' 'unsafe-inline' https://coco.infini.cloud;
-  img-src 'self' data: https://coco.infini.cloud;
-  connect-src 'self' https://coco.infini.cloud;
-  frame-src https://coco.infini.cloud;
-`,
+    contentSecurityPolicy: `
+      default-src 'self';
+      script-src 'self' https://coco.infini.cloud;
+      style-src 'self' 'unsafe-inline' https://coco.infini.cloud;
+      img-src 'self' data: https://coco.infini.cloud;
+      connect-src 'self' https://coco.infini.cloud;
+      frame-src https://coco.infini.cloud;
+    `,
     unoptimized: true,
   },
   distDir: isDev ? "out" : "docs",


### PR DESCRIPTION
This pull request updates the deployment workflow to replace the previous package manager detection logic with `pnpm`, streamlining dependency management and build processes. The changes also include adjustments to caching, build commands, and output directory paths.

### Package Manager Transition:
* Removed the custom package manager detection logic and replaced it with the `pnpm/action-setup@v4` action to use `pnpm` directly. (`.github/workflows/deploy-site.yml`, [.github/workflows/deploy-site.ymlL36-R45](diffhunk://#diff-0b263af13139bf9e35cf8d76ee84f4a007e7dc1d35f1f45c282eeec1449e6ce1L36-R45))
* Updated the Node.js setup step to cache dependencies using `pnpm`. (`.github/workflows/deploy-site.yml`, [.github/workflows/deploy-site.ymlL36-R45](diffhunk://#diff-0b263af13139bf9e35cf8d76ee84f4a007e7dc1d35f1f45c282eeec1449e6ce1L36-R45))

### Build and Cache Updates:
* Adjusted the cache restore keys to remove redundant trailing dashes. (`.github/workflows/deploy-site.yml`, [.github/workflows/deploy-site.ymlL92-R100](diffhunk://#diff-0b263af13139bf9e35cf8d76ee84f4a007e7dc1d35f1f45c282eeec1449e6ce1L92-R100))
* Replaced the dynamic dependency installation and build commands with explicit `pnpm install` and `pnpm build` commands for consistency and clarity. (`.github/workflows/deploy-site.yml`, [.github/workflows/deploy-site.ymlL92-R100](diffhunk://#diff-0b263af13139bf9e35cf8d76ee84f4a007e7dc1d35f1f45c282eeec1449e6ce1L92-R100))

### Output Directory Changes:
* Changed the output directory for the CNAME file and Jekyll disabling file from `./out` to `./docs`. (`.github/workflows/deploy-site.yml`, [.github/workflows/deploy-site.ymlL92-R100](diffhunk://#diff-0b263af13139bf9e35cf8d76ee84f4a007e7dc1d35f1f45c282eeec1449e6ce1L92-R100))