### PR TITLE
fix: version conflict with package.josn

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -36,7 +36,7 @@ jobs:
         
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          package_json_file: "package.json"
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
This pull request updates the configuration for the `deploy-site` GitHub Actions workflow, specifically in the `jobs` section, to improve clarity and ensure compatibility with the package manager setup.

Workflow configuration updates:

* [`.github/workflows/deploy-site.yml`](diffhunk://#diff-0b263af13139bf9e35cf8d76ee84f4a007e7dc1d35f1f45c282eeec1449e6ce1L39-R39): Updated the `pnpm/action-setup` step to include the `package_json_file` parameter with the value `"package.json"`, replacing the previous `version: latest` configuration. This change ensures that the correct `package.json` file is explicitly referenced during the setup process.